### PR TITLE
Update to llvm-hs(-pure) 5.1

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -15,6 +15,8 @@ import Control.Applicative
 import Control.Monad.State
 
 import LLVM.AST
+import LLVM.AST.Typed (typeOf)
+import LLVM.AST.AddrSpace
 import LLVM.AST.Type
 import LLVM.AST.Global
 import qualified LLVM.AST as AST
@@ -66,6 +68,18 @@ external retty label argtys = addDefn $
   , returnType  = retty
   , basicBlocks = []
   }
+
+fnPtr :: Name -> LLVM Type
+fnPtr nm = findType <$> gets moduleDefinitions
+  where
+    findType defs =
+      case fnDefByName of
+        []   -> error $ "Undefined function: " ++ show nm
+        [fn] -> PointerType (typeOf fn) (AddrSpace 0)
+        _    -> error $ "Ambiguous function name: " ++ show nm
+      where
+        globalDefs  = [g | GlobalDefinition g <- defs]
+        fnDefByName = [f | f@(Function { name = nm }) <- globalDefs]
 
 ---------------------------------------------------------------------------------
 -- Types

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -159,6 +159,12 @@ instr ty ins = do
   modifyBlock (blk { stack = (ref := ins) : i } )
   return $ local ty ref
 
+unnminstr :: Instruction -> Codegen ()
+unnminstr ins = do
+  blk <- current
+  let i = stack blk
+  modifyBlock (blk { stack = (Do ins) : i } )
+
 terminator :: Named Terminator -> Codegen (Named Terminator)
 terminator trm = do
   blk <- current
@@ -266,8 +272,8 @@ call fn args = instr float $ Call Nothing CC.C [] (Right fn) (toArgs args) [] []
 alloca :: Type -> Codegen Operand
 alloca ty = instr float $ Alloca ty Nothing 0 []
 
-store :: Operand -> Operand -> Codegen Operand
-store ptr val = instr float $ Store False ptr val Nothing 0 []
+store :: Operand -> Operand -> Codegen ()
+store ptr val = unnminstr $ Store False ptr val Nothing 0 []
 
 load :: Operand -> Codegen Operand
 load ptr = instr float $ Load False ptr Nothing 0 []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,7 @@
-resolver: lts-9.3
+resolver: lts-10.0
 packages:
 - '.'
-extra-deps:
-- llvm-hs-pure-5.0.0
-- llvm-hs-5.0.0
+extra-deps: []
 
 flags:
   llvm-hs:


### PR DESCRIPTION
* 825c8fb prevents llvm-hs from stopping with an error about instructions returning `void` (e.g., `store`) having a name,
* cc60b61 provides a function for easily getting pointers to inside-llvm-functions in the front end.

The following code (to be put in `src/Main.hs`) is an example where the commits help. If e.g., `double` was used instead of the function pointer then llvm-hs would stop with an error, see https://github.com/sdiehl/kaleidoscope/issues/45.

```
logic :: LLVM ()
logic = do
  define double "foo" [(double, "a")] $ do
    ret (local double (AST.mkName "a"))

  fooPtr <- fnPtr (AST.mkName "foo")

  define double "main" [] $ do
    let a = cons $ C.Float (F.Double 10)
    let b = cons $ C.Float (F.Double 20)

    a' <- call (externf fooPtr (AST.mkName "foo")) [a]

    c <- alloca double
    store c b
    c' <- load c
    res <- fadd a' c'

    ret res
```

The corresponding PR for the tutorial is https://github.com/sdiehl/kaleidoscope/pull/46.