### PR TITLE
Pass pointer-to-IR-function type to function defining body

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ initModule = emptyModule "my cool jit"
 
 logic :: LLVM ()
 logic = do
-  define double "main" [] $ do
+  define double "main" [] $ \ptrToMain -> do
     let a = cons $ C.Float (F.Double 10)
     let b = cons $ C.Float (F.Double 20)
     res <- fadd a b

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -22,7 +22,7 @@ initModule = emptyModule "my cool jit"
 
 logic :: LLVM ()
 logic = do
-  define double "main" [] $ do
+  define double "main" [] $ \ptrToMain -> do
     let a = cons $ C.Float (F.Double 10)
     let b = cons $ C.Float (F.Double 20)
     res <- fadd a b


### PR DESCRIPTION
This is a followup to https://github.com/llvm-hs/llvm-hs-kaleidoscope/pull/4 where I added `fnPtr` to get pointers to functions easily. As pointed out to me by Luke Evans this does not help with recursive functions.

This commit makes the `define` function pass the pointer-to-IR-function type to the function defining the IR-function's body. A trivial example is in `src/Main.hs`, an example where this is actually used for recursive calls is below.

```
{-# LANGUAGE OverloadedStrings #-}
import JIT
import Codegen
import qualified LLVM.AST as AST
import qualified LLVM.AST.Float as F
import qualified LLVM.AST.Constant as C
import qualified LLVM.AST.FloatingPointPredicate as FP

initModule :: AST.Module
initModule = emptyModule "my cool jit"

logic :: LLVM ()
logic = do
  define double "foo" [(double, AST.mkName "a")] $ \fooPtr -> do
    let a = local double (AST.mkName "a")
    let one = cons $ C.Float (F.Double 1)

    ifthen <- addBlock "if.then"
    ifelse <- addBlock "if.else"

    -- %entry
    test <- fcmp FP.OLT a one
    cbr test ifthen ifelse -- Branch based on the condition

    -- if.then
    setBlock ifthen
    ret one

    -- if.else
    setBlock ifelse
    am1 <- fsub a one
    recRes <- call (externf fooPtr (AST.mkName "foo")) [am1]
    res <- fadd recRes (cons $ C.Float (F.Double 1))
    ret res

  fooPtr <- fnPtr (AST.mkName "foo")

  define double "main" [] $ \mainPtr -> do
    a <- call (externf fooPtr (AST.mkName "foo")) [cons $ C.Float (F.Double 10)]
    b <- call (externf fooPtr (AST.mkName "foo")) [cons $ C.Float (F.Double 20)]
    res <- fadd a b
    ret res

main :: IO AST.Module
main = do
  let ast = runLLVM initModule logic
  rc <- runJIT ast
  return ast
```
  