### PR TITLE
Fix variable name in the pattern match.

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -87,7 +87,7 @@ fnPtr nm = findType <$> gets moduleDefinitions
         _    -> error $ "Ambiguous function name: " ++ show nm
       where
         globalDefs  = [g | GlobalDefinition g <- defs]
-        fnDefByName = [f | f@(Function { name = nm }) <- globalDefs]
+        fnDefByName = [f | f@(Function { name = nm' }) <- globalDefs, nm' == nm]
 
 ---------------------------------------------------------------------------------
 -- Types


### PR DESCRIPTION
I'm walking through this excellent example and learned a lot. Thanks for your work.

```
fnDefByName = [f | f@(Function { name = nm }) <- globalDefs]
```
I believe name in the pattern will catch the value, not match the value , and  this expression want to filter all the function that matches the name.

Here is the test that verified my thought.
```
data Test = Test {key::String} deriving Show
testList = [Test "a", Test "b", Test "c"]
filterKey = "a"
tryFiltered = [f | f@(Test filterKey) <- testList]
realFiltered = [f | f@(Test filterKey') <- testList, filterKey' == filterKey]
```
```
λ> testList
[Test {key = "a"},Test {key = "b"},Test {key = "c"}]
λ> tryFiltered
[Test {key = "a"},Test {key = "b"},Test {key = "c"}]
λ> realFiltered
[Test {key = "a"}]
```
